### PR TITLE
Module Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ dependencies {
 
 jar {
     from {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        configurations.runtimeClasspath.collect {  it.isDirectory() ? it : zipTree(it)  }
+        //duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        //configurations.runtimeClasspath.collect {  it.isDirectory() ? it : zipTree(it)  }
     } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
@@ -65,7 +65,7 @@ jar {
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
                 'Bundle-Description'    : description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.toolbox',
-                'Export-Package'        : 'eu.hansolo.toolbox,eu.hansolo.toolbox.properties,eu.hansolo.toolbox.evt,eu.hansolo.toolbox.evt.type,eu.hansolo.toolbox.tuples,eu.hansolo.toolbox.unit,eu.hansolo.toolbox.time',
+                'Export-Package'        : 'eu.hansolo.toolbox.evtbus, eu.hansolo.toolbox.evt.type, eu.hansolo.toolbox.evt, eu.hansolo.toolbox.geo, eu.hansolo.toolbox.observables, eu.hansolo.toolbox.properties, eu.hansolo.toolbox.statemachine, eu.hansolo.toolbox.tuples, eu.hansolo.toolbox.unit, eu.hansolo.toolbox.time, eu.hansolo.toolbox',
                 'Class-Path'            : configurations.runtimeClasspath.files.collect { it.getName() }.join(' '),
                 'Main-Class'            : 'eu.hansolo.toolbox.Demo'
         )

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module eu.hansolo.toolbox {
     exports eu.hansolo.toolbox.evtbus;
     exports eu.hansolo.toolbox.evt.type;
     exports eu.hansolo.toolbox.evt;
+    exports eu.hansolo.toolbox.geo;
     exports eu.hansolo.toolbox.observables;
     exports eu.hansolo.toolbox.properties;
     exports eu.hansolo.toolbox.statemachine;
@@ -13,4 +14,5 @@ module eu.hansolo.toolbox {
     exports eu.hansolo.toolbox.unit;
     exports eu.hansolo.toolbox.time;
     exports eu.hansolo.toolbox;
+
 }


### PR DESCRIPTION
This is a follow on to HanSolo/charts#109

This PR is 1/4 in an attempt to fix the following error I was getting when performing jlink of [Birdasaur/Trinity](https://github.com/Birdasaur/Trinity) with the latest charts (17.1.47). Realized this propagated from toolbox all the way to charts, so I apolize for the bunch of PR's. Note charts, countries were failing to jlink as well.

The error looked something like this, but it got better as I kept adding missing opens/exports:
```
Module eu.hansolo.fx.countries contains package eu.hansolo.toolboxfx, module eu.hansolo.toolboxfx exports package eu.hansolo.toolboxfx to eu.hansolo.fx.countries
```

Edit (linking other PRs):
https://github.com/HanSolo/toolboxfx/pull/1
https://github.com/HanSolo/countries/pull/8
https://github.com/HanSolo/charts/pull/110
